### PR TITLE
Fixes random segfault at start.

### DIFF
--- a/src/rasta.cpp
+++ b/src/rasta.cpp
@@ -555,7 +555,7 @@ void RastaConverter::OtherDithering()
 
 void RastaConverter::ShowInputBitmap()
 {
-	if (!cfg.preprocess_only)
+	if (!cfg.preprocess_only && input_bitmap)
 	{
 		acquire_screen();
 		if (desktop_width>=320*3)
@@ -591,7 +591,7 @@ void RastaConverter::ShowDestinationLine(int y)
 
 void RastaConverter::ShowDestinationBitmap()
 {
-	if (!cfg.preprocess_only)
+	if (!cfg.preprocess_only && destination_bitmap)
 	{
 		acquire_screen();
 		if (desktop_width>=320*3)


### PR DESCRIPTION
Ensure that the input and output bitmaps are created before showing to the screen, as sometimes the screen is being drawn before the bitmaps are initialized.
